### PR TITLE
Allow any valid blocks to be rendered, skipping invalid blocks

### DIFF
--- a/lib/editor_js/document.rb
+++ b/lib/editor_js/document.rb
@@ -36,9 +36,8 @@ module EditorJs
       blocks = @content['blocks'].map do |blk_data|
         EditorJs::Blocks::Base.load(blk_data)
       end
-      @valid = blocks.all?(&:valid?)
-      @blocks = blocks if @valid
-      @valid
+      @blocks = blocks.select(&:valid?)
+      @valid = @blocks.count.positive?
     end
 
     def render


### PR DESCRIPTION
Currently the logic renders nothing if any single block is invalid. I've changed this to render any blocks that are valid instead. Ideally the gem should allow configuring a logger so we can log when an invalid block is detected.